### PR TITLE
Fix code scanning alert no. 3: Use of implicit PendingIntents

### DIFF
--- a/app/src/main/java/technology/heli/helinote/feature/notification/scheduler/DefaultReminderScheduler.kt
+++ b/app/src/main/java/technology/heli/helinote/feature/notification/scheduler/DefaultReminderScheduler.kt
@@ -32,8 +32,8 @@ class DefaultReminderScheduler @Inject constructor(
         }
 
         val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
-        val intent = Intent(context, ReminderBroadcastReceiver::class.java).apply {
-            `package` = context.packageName
+        val intent = Intent().apply {
+            setClassName(context.packageName, ReminderBroadcastReceiver::class.java.name)
             putExtra(EXTRA_REMINDER_ID, reminder.id)
             putExtra(EXTRA_REMINDER_TITLE, reminderTitle)
             putExtra(EXTRA_REMINDER_MESSAGE, reminderMessage)
@@ -73,7 +73,9 @@ class DefaultReminderScheduler @Inject constructor(
 
     override fun cancel(reminderId: Long) {
         val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
-        val intent = Intent(context, ReminderBroadcastReceiver::class.java)
+        val intent = Intent().apply {
+            setClassName(context.packageName, ReminderBroadcastReceiver::class.java.name)
+        }
         val pendingIntent = PendingIntent.getBroadcast(
             context,
             reminderId.toInt(),


### PR DESCRIPTION
Fixes [https://github.com/farbod-s/Heli-Note/security/code-scanning/3](https://github.com/farbod-s/Heli-Note/security/code-scanning/3)

To fix the problem, we need to ensure that the `Intent` used to create the `PendingIntent` is explicit. This can be done by setting the component name explicitly in the `Intent`. This will prevent other applications from intercepting and modifying the `Intent`.

- Modify the `Intent` creation on line 35 to set the component name explicitly.
- Ensure that the `PendingIntent` is created with this explicit `Intent`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
