### PR TITLE
Fix code scanning alert no. 1: Use of implicit PendingIntents

### DIFF
--- a/app/src/main/java/technology/heli/helinote/feature/notification/NotificationHelper.kt
+++ b/app/src/main/java/technology/heli/helinote/feature/notification/NotificationHelper.kt
@@ -49,8 +49,8 @@ class NotificationHelper @Inject constructor(
         val notificationManager =
             context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
-        val intent = Intent(context, MainActivity::class.java).apply {
-            `package` = context.packageName
+        val intent = Intent().apply {
+            setClass(context, MainActivity::class.java)
             flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
         }
         val pendingIntent =


### PR DESCRIPTION
Fixes [https://github.com/farbod-s/Heli-Note/security/code-scanning/1](https://github.com/farbod-s/Heli-Note/security/code-scanning/1)

To fix the problem, we need to ensure that the `Intent` used to create the `PendingIntent` is explicit. This can be done by setting the component explicitly in the `Intent`. We will modify the `Intent` creation on line 52 to set the component explicitly using `setClass`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
